### PR TITLE
Add None singleton and is/isnot operators

### DIFF
--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -28,6 +28,7 @@ String literls can be single or double quoted::
 
 Boolean literals are the bare values ``true`` and ``false``
 
+``None`` type is the bare value ``none``
 
 Property paths
 ==============
@@ -46,16 +47,18 @@ that order.
 Basic comparison operators
 ==========================
 
-=======================  ========================  ===========
+=======================  ========================  =====================
 Operator                 Description               Example
-=======================  ========================  ===========
+=======================  ========================  =====================
 ``=``, ``==``, ``eq``    Equality                  ``foo == 5``
 ``!=``, ``!==``, ``ne``  Inequality                ``bar != 5``
 ``>``, ``gt``            Greater than              ``foo > 5``
 ``>=``, ``gte``          Greater than or equal to  ``foo >= 5``
 ``<``, ``lt``            Less than                 ``foo < 5``
 ``<=``, ``lte``          Less than or equal to     ``foo <= 5``
-=======================  ========================  ===========
+``is``                   Identity                  ``foo is True``
+``isnot``                Inverse identity          ``foobar isnot True``
+=======================  ========================  =====================
 
 
 Logical operators

--- a/tests/test_boolrule.py
+++ b/tests/test_boolrule.py
@@ -11,6 +11,7 @@ from boolrule import BoolRule, MissingVariableException
     ('5 < 3', False),
     ('7 == true', False),
     ('true == true', True),
+    ('None is None', True),
 ])
 def test_simple_comparisons(s, expected):
     boolrule = BoolRule(s)
@@ -42,6 +43,9 @@ def test_nested_logical_combinations(s, expected):
     ('foo = "bar" AND baz > 10', {'foo': 'bar', 'baz': 9}, False),
     ('foo = "bar" AND ("a" = "b" OR baz > 10)', {'foo': 'bar', 'baz': 11}, True),
     ('foo.bar = "bar"', {'foo': {'bar': 'bar'}}, True),
+    ('foo.bar isnot none', {'foo': {'bar': 4}}, True),
+    ('foo.bar is none', {'foo': {'bar': 4}}, False),
+    ('foo.bar is none', {'foo': {'bar': None}}, True),
 ])
 def test_subsitution_values(s, context, expected):
     boolrule = BoolRule(s)


### PR DESCRIPTION
Hi!

First of all, thank you for this. Boolrule is concise and very well written, exactly what I was looking for!

This pull request implements two new features that I needed:

1. Add ``none`` as a singleton value in the same way ``true`` and ``false`` exists.
2. Add the operators ``is`` and ``isnot`` to test identity.

The reason for this two new features is explained in [PEP8](https://www.python.org/dev/peps/pep-0008/#programming-recommendations):
> Comparisons to singletons like None should always be done with is or is not, never the equality operators. 

This pull request include updated docs and 3 new tests for the new values and operators.

Thanks!



