### PR TITLE
Add support for accessing booleans directly

### DIFF
--- a/boolrule/boolrule.py
+++ b/boolrule/boolrule.py
@@ -108,6 +108,7 @@ boolExpression = Forward()
 boolCondition = Group(
     (Group(propertyVal)('lval') + binaryOp + Group(propertyVal)('rval'))
     | (lparen + boolExpression + rparen)
+    | propertyVal
 )
 boolExpression << boolCondition + ZeroOrMore((and_ | or_) + boolExpression)
 
@@ -187,10 +188,13 @@ class BoolRule(object):
                     return True
                 elif token == 'and' and not passed:
                     return False
+                elif isinstance(token, SubstituteVal):
+                    passed = self._expand_val(token, context) is True
                 continue
 
             if not token.getName():
-                return self._test_tokens(token, context)
+                passed = self._test_tokens(token, context)
+                continue
 
             items = token.asDict()
 

--- a/tests/test_boolrule.py
+++ b/tests/test_boolrule.py
@@ -55,6 +55,15 @@ def test_nested_logical_combinations(s, expected):
 
 
 @pytest.mark.parametrize('s,context,expected', [
+    ('foo', {'foo': True}, True),
+    ('foo', {'foo': False}, False),
+    ('foo', {'foo': 'nope'}, False),
+    ('foo or bar', {'foo': False, 'bar': True}, True),
+    ('foo or bar', {'foo': True, 'bar': False}, True),
+    ('foo or bar', {'foo': False, 'bar': False}, False),
+    ('foo and bar', {'foo': True, 'bar': False}, False),
+    ('foo and bar', {'foo': True, 'bar': True}, True),
+    ('(1=0) or (1=1)', {}, True),
     ('foo = "bar" AND baz > 10', {'foo': 'bar', 'baz': 20}, True),
     ('foo = "bar" AND baz > 10', {'foo': 'bar', 'baz': 9}, False),
     (


### PR DESCRIPTION
This allows constructs like `foo` to access contexts like `{"foo": True}`. And bracketing sub-expressions like `(1 == 0) or (1 == 1)`.