### PR TITLE
Fix recursion error for 'and' operator. 

### DIFF
--- a/boolrule/boolrule.py
+++ b/boolrule/boolrule.py
@@ -190,7 +190,8 @@ class BoolRule(object):
                 continue
 
             if not token.getName():
-                return self._test_tokens(token, context)
+                passed = self._test_tokens(token, context)
+                continue
 
             items = token.asDict()
 

--- a/tests/test_boolrule.py
+++ b/tests/test_boolrule.py
@@ -53,6 +53,13 @@ def test_nested_logical_combinations(s, expected):
     boolrule = BoolRule(s)
     assert boolrule.test() == expected
 
+@pytest.mark.parametrize('s,expected', [
+    ('(1=1 or 2=2) and (3 = 3)', True),
+    ('(1=1 or 2=2) and (3 = 4)', False),
+])
+def test_nested_logical_combinations_and_error(s, expected):
+    boolrule = BoolRule(s)
+    assert boolrule.test() == expected
 
 @pytest.mark.parametrize('s,context,expected', [
     ('foo = "bar" AND baz > 10', {'foo': 'bar', 'baz': 20}, True),


### PR DESCRIPTION
When test expr like `"(a=1 or b=2 ) and (d = 4)"`, with value`{"a":1, "b":2, "d":3}`, the test result is wrong. Expected is false but got true. Cause: After testing `'(a=1 or b=2)'` part is done, `_test_tokens` returned.